### PR TITLE
feat: Amend to NewAlpacaAPI() to allow for more versatility.

### DIFF
--- a/pkg/alpaca/alapca_test.go
+++ b/pkg/alpaca/alapca_test.go
@@ -3,7 +3,7 @@ package alpaca
 import "testing"
 
 func TestNewAlpacaAPIBaseURL(t *testing.T) {
-	client := NewAlpacaAPI(65535, "0.0.0.0", 8000)
+	client := NewAlpacaAPI(65535, false, "", "0.0.0.0", 8000)
 
 	var got string = client.urlBase
 	var want string = "http://0.0.0.0:8000"
@@ -13,8 +13,19 @@ func TestNewAlpacaAPIBaseURL(t *testing.T) {
 	}
 }
 
+func TestNewAlpacaAPIBaseURLForHost(t *testing.T) {
+	client := NewAlpacaAPI(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1)
+
+	var got string = client.urlBase
+	var want string = "https://virtserver.swaggerhub.com/ASCOMInitiative"
+
+	if got != want {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
 func TestNewAlpacaAPIClientID(t *testing.T) {
-	client := NewAlpacaAPI(65535, "0.0.0.0", 8000)
+	client := NewAlpacaAPI(65535, false, "", "0.0.0.0", 8000)
 
 	var got uint32 = client.clientId
 	var want uint32 = 65535
@@ -25,7 +36,7 @@ func TestNewAlpacaAPIClientID(t *testing.T) {
 }
 
 func TestNewAlpacaAPITransactionID(t *testing.T) {
-	client := NewAlpacaAPI(65535, "0.0.0.0", 8000)
+	client := NewAlpacaAPI(65535, false, "", "0.0.0.0", 8000)
 
 	var got uint32 = client.transactionId
 	var want uint32 = 0
@@ -36,7 +47,7 @@ func TestNewAlpacaAPITransactionID(t *testing.T) {
 }
 
 func TestNewAlpacaAPIQueryString(t *testing.T) {
-	client := NewAlpacaAPI(65535, "0.0.0.0", 8000)
+	client := NewAlpacaAPI(65535, false, "", "0.0.0.0", 8000)
 
 	var got string = client.getQueryString()
 	var want string = "ClientID=65535&ClientTransactionID=0"
@@ -47,7 +58,7 @@ func TestNewAlpacaAPIQueryString(t *testing.T) {
 }
 
 func TestNewAlpacaAPIEndpoint(t *testing.T) {
-	client := NewAlpacaAPI(65535, "0.0.0.0", 8000)
+	client := NewAlpacaAPI(65535, false, "", "0.0.0.0", 8000)
 
 	var got string = client.getEndpoint("telescope", 0, "canslew")
 	var want string = "http://0.0.0.0:8000/api/v1/telescope/0/canslew"

--- a/pkg/alpaca/alpaca.go
+++ b/pkg/alpaca/alpaca.go
@@ -17,10 +17,22 @@ type ASCOMAlpacaAPIClient struct {
 	errorMessage  string
 }
 
-func NewAlpacaAPI(clientId uint32, ip string, port int32) *ASCOMAlpacaAPIClient {
+func NewAlpacaAPI(clientId uint32, secure bool, domain string, ip string, port int32) *ASCOMAlpacaAPIClient {
+	var protocol string = "https"
+
+	if !secure {
+		protocol = "http"
+	}
+
+	var urlBase string = fmt.Sprintf("%s://%s:%d", protocol, ip, port)
+
+	if port == -1 && len(domain) > 0 {
+		urlBase = fmt.Sprintf("%s://%s", protocol, domain)
+	}
+
 	client := ASCOMAlpacaAPIClient{
 		client:        resty.New(),
-		urlBase:       fmt.Sprintf("http://%s:%d", ip, port),
+		urlBase:       urlBase,
 		clientId:      clientId,
 		transactionId: 0,
 	}


### PR DESCRIPTION
feat: Amend to NewAlpacaAPI() to allow for either ip:port or domain, as well as secure protocol. 

Includes associated test suite for module export definition and expected output.