### PR TITLE
feat: Added (t *Telescope) CanPulseGuide().

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -135,3 +135,13 @@ func (t *Telescope) CanFindHome() (bool, error) {
 func (t *Telescope) CanPark() (bool, error) {
 	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "canpark")
 }
+
+/*
+	CanPulseGuide()
+
+	@returns true if this telescope is capable of software-pulsed guiding (via the PulseGuide(GuideDirections, Int32) method)
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__canpulseguide
+*/
+func (t *Telescope) CanPulseGuide() (bool, error) {
+	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "canpulseguide")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-var delay time.Duration = 1
+var delay time.Duration = 2
 
 func TestNewTelescopeBaseURL(t *testing.T) {
 	telescope := NewTelescope(65535, false, "", "0.0.0.0", 8000, 0, 1)
@@ -256,6 +256,28 @@ func TestNewTelescopeCanPark(t *testing.T) {
 	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
 
 	var got, err = telescope.CanPark()
+
+	var want bool = true
+
+	if err != nil {
+		t.Errorf("got %q, wanted %t", err, want)
+	}
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
+	}
+}
+
+func TestNewTelescopeCanPulseGuide(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.CanPulseGuide()
 
 	var want bool = true
 


### PR DESCRIPTION
feat: Added CanPulseGuide() to alpaca module. 

Includes associated test suite for module export definition and expected output.