### PR TITLE
feat: Added (t *Telescope) CanSetGuideRates().

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -155,3 +155,13 @@ func (t *Telescope) CanPulseGuide() (bool, error) {
 func (t *Telescope) CanSetDeclinationRate() (bool, error) {
 	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansetdeclinationrate")
 }
+
+/*
+	CanSetGuideRates()
+
+	@returns true if the guide rate properties used for PulseGuide(GuideDirections, Int32) can ba adjusted.
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__cansetguiderates
+*/
+func (t *Telescope) CanSetGuideRates() (bool, error) {
+	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansetguiderates")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -315,3 +315,25 @@ func TestNewTelescopeCanSetDeclinationRate(t *testing.T) {
 		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
 	}
 }
+
+func TestNewTelescopeCanSetGuideRates(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.CanSetGuideRates()
+
+	var want bool = true
+
+	if err != nil {
+		t.Errorf("got %q, wanted %t", err, want)
+	}
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
+	}
+}


### PR DESCRIPTION
feat: Added CanSetGuideRates() to alpaca module. 

Includes associated test suite for module export definition and expected output.