### PR TITLE
feat: Added (t *Telescope) CanSetRightAscensionRate().

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -185,3 +185,13 @@ func (t *Telescope) CanSetPark() (bool, error) {
 func (t *Telescope) CanSetPierSide() (bool, error) {
 	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansetpierside")
 }
+
+/*
+	CanSetRightAscensionRate()
+
+	@returns true if the RightAscensionRate property can be changed to provide offset tracking in the right ascension axis.
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__cansetrightascensionrate
+*/
+func (t *Telescope) CanSetRightAscensionRate() (bool, error) {
+	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansetrightascensionrate")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -381,3 +381,25 @@ func TestNewTelescopeCanSetPierSide(t *testing.T) {
 		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
 	}
 }
+
+func TestNewTelescopeCanSetRightAscensionRate(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.CanSetRightAscensionRate()
+
+	var want bool = true
+
+	if err != nil {
+		t.Errorf("got %q, wanted %t", err, want)
+	}
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
+	}
+}


### PR DESCRIPTION
feat: Added CanSetRightAscensionRate() to alpaca module. 

Includes associated test suite for module export definition and expected output.