### PR TITLE
feat: Added (t *Telescope) CanSetTracking().

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -195,3 +195,13 @@ func (t *Telescope) CanSetPierSide() (bool, error) {
 func (t *Telescope) CanSetRightAscensionRate() (bool, error) {
 	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansetrightascensionrate")
 }
+
+/*
+	CanSetTracking()
+
+	@returns true if the Tracking property can be changed, turning telescope sidereal tracking on and off.
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__cansettracking
+*/
+func (t *Telescope) CanSetTracking() (bool, error) {
+	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "cansettracking")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -403,3 +403,25 @@ func TestNewTelescopeCanSetRightAscensionRate(t *testing.T) {
 		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
 	}
 }
+
+func TestNewTelescopeCanSetTracking(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.CanSetTracking()
+
+	var want bool = true
+
+	if err != nil {
+		t.Errorf("got %q, wanted %t", err, want)
+	}
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
+	}
+}


### PR DESCRIPTION
feat: Added CanSetTracking() to alpaca module. 

Includes associated test suite for module export definition and expected output.