### PR TITLE
feat: Added (t *Telescope) CanSlewAltAzAsync().

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -225,3 +225,13 @@ func (t *Telescope) CanSlew() (bool, error) {
 func (t *Telescope) CanSlewAltAz() (bool, error) {
 	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "canslewaltaz")
 }
+
+/*
+	CanSlewAltAzAsync()
+
+	@returns true if this telescope is capable of programmed asynchronous slewing to local horizontal coordinates
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__canslewaltazasync
+*/
+func (t *Telescope) CanSlewAltAzAsync() (bool, error) {
+	return t.Alpaca.GetBooleanResponse("telescope", t.DeviceNumber, "canslewaltazasync")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -469,3 +469,25 @@ func TestNewTelescopeCanSlewAltAz(t *testing.T) {
 		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
 	}
 }
+
+func TestNewTelescopeCanSlewAltAzAsync(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.CanSlewAltAzAsync()
+
+	var want bool = true
+
+	if err != nil {
+		t.Errorf("got %q, wanted %t", err, want)
+	}
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %t", telescope.Alpaca.ErrorMessage, want)
+	}
+}


### PR DESCRIPTION
feat: Added CanSlewAltAzAsync() to alpaca module. 

Includes associated test suite for module export definition and expected output.