### PR TITLE
feat: Added (t *Telescope) GetFocalLength() to alpaca module.

### DIFF
--- a/pkg/alpaca/telescope.go
+++ b/pkg/alpaca/telescope.go
@@ -325,3 +325,13 @@ func (t *Telescope) GetEquatorialSystem() (EquatorialSystem, error) {
 	system, err := t.Alpaca.GetInt32Response("telescope", t.DeviceNumber, "equatorialsystem")
 	return EquatorialSystem(system), err
 }
+
+/*
+	GetFocalLength()
+
+	@returns the telescope's focal length in meters
+	@see https://ascom-standards.org/api/#/Telescope%20Specific%20Methods/get_telescope__device_number__focallength
+*/
+func (t *Telescope) GetFocalLength() (float64, error) {
+	return t.Alpaca.GetFloat64Response("telescope", t.DeviceNumber, "focallength")
+}

--- a/pkg/alpaca/telescope_test.go
+++ b/pkg/alpaca/telescope_test.go
@@ -666,3 +666,25 @@ func TestNewTelescopeEquatorialSystem(t *testing.T) {
 		t.Errorf("got %q, wanted %d", telescope.Alpaca.ErrorMessage, want)
 	}
 }
+
+func TestNewTelescopeFocalLength(t *testing.T) {
+	time.Sleep(delay * time.Second)
+
+	telescope := NewTelescope(65535, true, "virtserver.swaggerhub.com/ASCOMInitiative", "", -1, 0, 1)
+
+	var got, err = telescope.GetFocalLength()
+
+	var want float64 = 1.1
+
+	if err != nil {
+		t.Errorf("got %q, wanted %f", err, want)
+	}
+
+	if math.Abs(got-want) > 0.00001 {
+		t.Errorf("got %f, wanted %f", got, want)
+	}
+
+	if telescope.Alpaca.ErrorNumber != 0 {
+		t.Errorf("got %q, wanted %f", telescope.Alpaca.ErrorMessage, want)
+	}
+}


### PR DESCRIPTION
feat: Added GetFocalLength() to alpaca module. 

Includes associated test suite for module export definition and expected output.